### PR TITLE
Fix #2 - Delay interpolations on render

### DIFF
--- a/cjs/async.js
+++ b/cjs/async.js
@@ -1,16 +1,35 @@
 'use strict';
-const {hooked} = require('uhooks-nofx/async');
+const {isArray} = require('uarray');
+const {
+  html: $html,
+  svg: $svg,
+  render: $render
+} = require('uhtml-ssr/async');
 
-function Component(f) {
-  return hooked(f);
-}
+const html =  async (template, ...values) => {
+  await unrollValues(values);
+  return $html(template, ...values);
+};
+html.for = createFor($html);
+
+const svg =  async (template, ...values) => {
+  await unrollValues(values);
+  return $svg(template, ...values);
+};
+svg.for = createFor($svg);
+
+const render = async (where, what) => {
+  const value = await (typeof what === 'function' ? what() : what);
+  return $render(
+    where,
+    await (value instanceof Hook ? unroll(value) : value)
+  );
+};
+
 exports.Component = Component;
-
-(m => {
-  exports.render = m.render;
-  exports.html = m.html;
-  exports.svg = m.svg;
-})(require('uhtml-ssr/async'));
+exports.render = render;
+exports.html = html;
+exports.svg = svg;
 
 (m => {
   exports.createContext = m.createContext;
@@ -22,4 +41,38 @@ exports.Component = Component;
   exports.useReducer = m.useReducer;
   exports.useState = m.useState;
   exports.useRef = m.useRef;
-})(require('uhooks-nofx/async'));
+})(require('uhooks-nofx'));
+
+const unroll = ({f, c, a}) => f.apply(c, a);
+
+const unrollValues = async (values) => {
+  const {length} = values;
+  for (let i = 0; i < length; i++) {
+    const hook = await values[i];
+    if (hook instanceof Hook)
+      values[i] = await unroll(hook);
+    else if (isArray(hook))
+      await unrollValues(hook);
+  }
+};
+
+function Component(f) {
+  return function () {
+    return new Hook(f, this, arguments);
+  };
+}
+
+function Hook(f, c, a) {
+  this.f = f;
+  this.c = c;
+  this.a = a;
+}
+
+function createFor(uhtml) {
+  return (e, id) => {
+    return async (template, ...values) => {
+      await unrollValues(values);
+      return uhtml.for(e, id)(template, ...values);
+    };
+  };
+}

--- a/cjs/index.js
+++ b/cjs/index.js
@@ -1,16 +1,35 @@
 'use strict';
-const {hooked} = require('uhooks-nofx');
+const {isArray} = require('uarray');
+const {
+  html: $html,
+  svg: $svg,
+  render: $render
+} = require('uhtml-ssr');
 
-function Component(f) {
-  return hooked(f);
-}
+const html =  /*async*/ (template, ...values) => {
+  /*await*/ unrollValues(values);
+  return $html(template, ...values);
+};
+html.for = createFor($html);
+
+const svg =  /*async*/ (template, ...values) => {
+  /*await*/ unrollValues(values);
+  return $svg(template, ...values);
+};
+svg.for = createFor($svg);
+
+const render = /*async*/ (where, what) => {
+  const value = /*await*/ (typeof what === 'function' ? what() : what);
+  return $render(
+    where,
+    /*await*/ (value instanceof Hook ? unroll(value) : value)
+  );
+};
+
 exports.Component = Component;
-
-(m => {
-  exports.render = m.render;
-  exports.html = m.html;
-  exports.svg = m.svg;
-})(require('uhtml-ssr'));
+exports.render = render;
+exports.html = html;
+exports.svg = svg;
 
 (m => {
   exports.createContext = m.createContext;
@@ -23,3 +42,37 @@ exports.Component = Component;
   exports.useState = m.useState;
   exports.useRef = m.useRef;
 })(require('uhooks-nofx'));
+
+const unroll = ({f, c, a}) => f.apply(c, a);
+
+const unrollValues = /*async*/ (values) => {
+  const {length} = values;
+  for (let i = 0; i < length; i++) {
+    const hook = /*await*/ values[i];
+    if (hook instanceof Hook)
+      values[i] = /*await*/ unroll(hook);
+    else if (isArray(hook))
+      /*await*/ unrollValues(hook);
+  }
+};
+
+function Component(f) {
+  return function () {
+    return new Hook(f, this, arguments);
+  };
+}
+
+function Hook(f, c, a) {
+  this.f = f;
+  this.c = c;
+  this.a = a;
+}
+
+function createFor(uhtml) {
+  return (e, id) => {
+    return /*async*/ (template, ...values) => {
+      /*await*/ unrollValues(values);
+      return uhtml.for(e, id)(template, ...values);
+    };
+  };
+}

--- a/esm/async.js
+++ b/esm/async.js
@@ -1,14 +1,69 @@
-import {hooked} from 'uhooks-nofx/async';
+import {isArray} from 'uarray';
+import {
+  html as $html,
+  svg as $svg,
+  render as $render
+} from 'uhtml-ssr/async';
 
-export function Component(f) {
-  return hooked(f);
+const html =  async (template, ...values) => {
+  await unrollValues(values);
+  return $html(template, ...values);
+};
+html.for = createFor($html);
+
+const svg =  async (template, ...values) => {
+  await unrollValues(values);
+  return $svg(template, ...values);
+};
+svg.for = createFor($svg);
+
+const render = async (where, what) => {
+  const value = await (typeof what === 'function' ? what() : what);
+  return $render(
+    where,
+    await (value instanceof Hook ? unroll(value) : value)
+  );
 };
 
-export {render, html, svg} from 'uhtml-ssr/async';
+export {Component, render, html, svg};
 
 export {
   createContext, useContext,
   useCallback, useMemo,
   useEffect, useLayoutEffect,
   useReducer, useState, useRef
-} from 'uhooks-nofx/async';
+} from 'uhooks-nofx';
+
+const unroll = ({f, c, a}) => f.apply(c, a);
+
+const unrollValues = async (values) => {
+  const {length} = values;
+  for (let i = 0; i < length; i++) {
+    const hook = await values[i];
+    if (hook instanceof Hook)
+      values[i] = await unroll(hook);
+    else if (isArray(hook))
+      await unrollValues(hook);
+  }
+};
+
+function Component(f) {
+  return function () {
+    return new Hook(f, this, arguments);
+  };
+}
+
+function Hook(f, c, a) {
+  this.f = f;
+  this.c = c;
+  this.a = a;
+}
+
+function createFor(uhtml) {
+  return (e, id) => {
+    return async (template, ...values) => {
+      await unrollValues(values);
+      return uhtml.for(e, id)(template, ...values);
+    };
+  };
+}

--- a/esm/index.js
+++ b/esm/index.js
@@ -1,10 +1,31 @@
-import {hooked} from 'uhooks-nofx';
+import {isArray} from 'uarray';
+import {
+  html as $html,
+  svg as $svg,
+  render as $render
+} from 'uhtml-ssr';
 
-export function Component(f) {
-  return hooked(f);
+const html =  /*async*/ (template, ...values) => {
+  /*await*/ unrollValues(values);
+  return $html(template, ...values);
+};
+html.for = createFor($html);
+
+const svg =  /*async*/ (template, ...values) => {
+  /*await*/ unrollValues(values);
+  return $svg(template, ...values);
+};
+svg.for = createFor($svg);
+
+const render = /*async*/ (where, what) => {
+  const value = /*await*/ (typeof what === 'function' ? what() : what);
+  return $render(
+    where,
+    /*await*/ (value instanceof Hook ? unroll(value) : value)
+  );
 };
 
-export {render, html, svg} from 'uhtml-ssr';
+export {Component, render, html, svg};
 
 export {
   createContext, useContext,
@@ -12,3 +33,37 @@ export {
   useEffect, useLayoutEffect,
   useReducer, useState, useRef
 } from 'uhooks-nofx';
+
+const unroll = ({f, c, a}) => f.apply(c, a);
+
+const unrollValues = /*async*/ (values) => {
+  const {length} = values;
+  for (let i = 0; i < length; i++) {
+    const hook = /*await*/ values[i];
+    if (hook instanceof Hook)
+      values[i] = /*await*/ unroll(hook);
+    else if (isArray(hook))
+      /*await*/ unrollValues(hook);
+  }
+};
+
+function Component(f) {
+  return function () {
+    return new Hook(f, this, arguments);
+  };
+}
+
+function Hook(f, c, a) {
+  this.f = f;
+  this.c = c;
+  this.a = a;
+}
+
+function createFor(uhtml) {
+  return (e, id) => {
+    return /*async*/ (template, ...values) => {
+      /*await*/ unrollValues(values);
+      return uhtml.for(e, id)(template, ...values);
+    };
+  };
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Same uland API for SSR / DOM-less environments",
   "main": "./cjs/index.js",
   "scripts": {
-    "build": "npm run cjs && npm run test",
+    "build": "npm run async && npm run cjs && npm run test",
     "cjs": "ascjs esm cjs",
+    "async": "cp esm/index.js esm/async.js && sed -i.bck 's/uhtml-ssr/uhtml-ssr\\/async/; s/\\/\\*async\\*\\//async/; s/\\/\\*await\\*\\//await/' esm/async.js && rm -rf  esm/async.js.bck",
     "test": "node test/index.js && node test/async.js"
   },
   "keywords": [
@@ -32,6 +33,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
+    "uarray": "^1.0.0",
     "uhooks-nofx": "^0.2.0",
     "uhtml-ssr": "^0.5.0"
   },

--- a/test/context-async.js
+++ b/test/context-async.js
@@ -1,0 +1,36 @@
+const {
+  Component,
+  createContext,
+  html,
+  render,
+  useContext,
+} = require("../cjs/async");
+
+const FooContext = createContext();
+
+const FooComponent = Component(() => {
+  const value = useContext(FooContext);
+  return html`<div>${value}</div>`;
+});
+
+async function doRender(fooValue) {
+  FooContext.provide(fooValue);
+
+  // Realistically, a delay would happen inside rendering of complex components.
+  await new Promise((resolve) => setTimeout(resolve, 1));
+
+  const renderedHtml = await render(
+    String,
+    () =>
+      html`<!DOCTYPE html>
+  <html>
+    ${FooComponent()}
+  </html>
+  `,
+  );
+
+  console.log(renderedHtml);
+}
+
+doRender("123");
+doRender("456");

--- a/test/context.js
+++ b/test/context.js
@@ -1,0 +1,31 @@
+const {
+  Component,
+  createContext,
+  html,
+  render,
+  useContext,
+} = require("../cjs");
+
+const FooContext = createContext();
+
+const Inner = Component(() => {
+  const value = useContext(FooContext);
+  return html`<div>${value}</div>`;
+});
+
+const Outer = Component(({ fooValue, children }) => {
+  FooContext.provide(fooValue);
+  return html`<div>${children}</div>`;
+});
+
+const renderedHtml = render(
+  String,
+  () =>
+    html`<!DOCTYPE html>
+<html>
+  ${Outer({ fooValue: "123", children: Inner() })}
+</html>
+`,
+);
+
+console.log(renderedHtml);


### PR DESCRIPTION
This MR does the following:

  * provide a facade of `html` and `svg` *uhtml-ssr* guards, resolving values right away
  * provide a `Hook` constructor to delay hooked values on invocation
  * provide an *async* export that mimics *uland* async logic

This MR passes now the `test/context.js` but it doesn't pass the `text/context-async.js`.

The reason looks pretty simple: while the `useContext` seems to have the right logic, `context.provide` doesn't bind the value with the currently executed callback, so we are back to [this issue](https://github.com/WebReflection/uhooks/issues/2) and the fact that `context.provide` needs somehow to map provided values to the invoking function.

This error can only happen in asynchronous code, if multiple renders are called one after the other, but this issue might also be bound to the SSR version of these libraries, once async, so I need to double check if *uland* client suffers the same issue, although, arguably, sharing a context per component and change it *should* result in latest context value used/updated per components, but on SSR the use case with context might be different, and last value should *not* affect previous calls.